### PR TITLE
Add support for heading in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,20 @@ In your template files, add the plugin's CSS style in the `head` section:
 You can change the default configuration by adding values to your `config.php` file. Here are the options available and what they do.
 * `toc_max_level` - Maximum header level displayed in the table of contents. - *Default value: 5*.
 * `toc_min_headers` - Minimum number of headers required. - *Default value: 2*
+* `toc_heading` - Heading text, if a heading for the table of contents is desired. - *Default value: (unset)*
 
 For reference, these values are set in `config.php` using the following format:
 
 ``` yml
 toc_max_level: 5
 toc_min_headers: 2
+toc_heading: Contents
 ```
 
-This configuration will be applied to the entire site, but it's also possible to override the `toc_max_level` for a specific element using the attribute `max-level`.
+This configuration will be applied to the entire site, but it's also possible to override the `toc_max_level` and `toc_heading` for a specific element using the `max-level` and `heading` attributes, respectively.
 
 ``` html
-<toc max-level="4" />
+<toc max-level="4" heading="Table of Contents" />
 ```
 
 ### Example

--- a/TableOfContents/TableOfContents.php
+++ b/TableOfContents/TableOfContents.php
@@ -88,8 +88,12 @@ class TableOfContents extends AbstractPicoPlugin
             $div_element->setAttribute('id', 'toc');
 
             // Add heading element, if enabled
-            if (isset($this->heading)) {
-                $heading_element = $document->createElement('div', $this->heading);
+            $heading = $toc_element->getAttribute('heading');
+            if ($heading === '') {
+                $heading = $this->heading;
+            }
+            if (isset($heading)) {
+                $heading_element = $document->createElement('div', $heading);
                 $heading_element->setAttribute('class', 'toc-heading');
                 $div_element->appendChild($heading_element);
             }

--- a/TableOfContents/TableOfContents.php
+++ b/TableOfContents/TableOfContents.php
@@ -32,6 +32,9 @@ class TableOfContents extends AbstractPicoPlugin
         if (isset($config['toc_min_headers'])) {
             $this->min_headers = &$config['toc_min_headers'];
         }
+        if (isset($config['toc_heading'])) {
+            $this->heading = &$config['toc_heading'];
+        }
     }
 
     /**
@@ -83,6 +86,14 @@ class TableOfContents extends AbstractPicoPlugin
             // Initialize Table Of Contents element
             $div_element = $document->createElement('div');
             $div_element->setAttribute('id', 'toc');
+
+            // Add heading element, if enabled
+            if (isset($this->heading)) {
+                $heading_element = $document->createElement('div', $this->heading);
+                $heading_element->setAttribute('class', 'toc-heading');
+                $div_element->appendChild($heading_element);
+            }
+
             $ul_element = $document->createElement('ul');
 
             // Add missing id's to the h tags

--- a/TableOfContents/style.css
+++ b/TableOfContents/style.css
@@ -40,3 +40,8 @@
 .toc-h6 {
     margin-left: 2.5em;
 }
+
+.toc-heading {
+  font-size  : larger;
+  font-weight: bold;
+}


### PR DESCRIPTION
- If the `toc_heading` configuration setting or the `<toc />` element's `heading` attribute is set, use its value as heading text
- Style heading using `toc-heading` class