### PR TITLE
Allow to use only Twigs {{ toc }} in template without [toc] in page .md

### DIFF
--- a/TableOfContents.php
+++ b/TableOfContents.php
@@ -162,10 +162,11 @@ class TableOfContents extends AbstractPicoPlugin
         foreach ($nodes as $node) {
             if (trim($node->nodeValue) === "[toc]") {
                 $node->parentNode->replaceChild($div_element, $node);
-                $content = preg_replace(array("/<(!DOCTYPE|\?xml).+?>/", "/<\/?(html|body)>/"), array("", ""), $document->saveHTML());
                 break;
             }
         }
+
+        $content = preg_replace(array("/<(!DOCTYPE|\?xml).+?>/", "/<\/?(html|body)>/"), array("", ""), $document->saveHTML());
 
         // Save the TOC element as string
         $this->toc_element_xml = $div_element->ownerDocument->saveXML($div_element);


### PR DESCRIPTION
When you try to place TOC in Twig template using {{toc}} without placing [toc] in page .md file, the html content will not be replaced causing TOC links will not work.